### PR TITLE
Improve layout responsiveness across breakpoints

### DIFF
--- a/src/components/CategoriesDetails.tsx
+++ b/src/components/CategoriesDetails.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 const CategoriesDetails = styled.div`
 
     width: 100%;
-    max-width: 1200px;
+    max-width: min(1400px, 96vw);
 
     display: flex;
     align-items: center;

--- a/src/components/LastNewsDetails.tsx
+++ b/src/components/LastNewsDetails.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 const LastNewsDetails = styled.div`
     width: 100%;
-    max-width: 1200px;
+    max-width: min(1400px, 96vw);
     display: flex;
 
     .container {

--- a/src/components/SlideDetails.tsx
+++ b/src/components/SlideDetails.tsx
@@ -14,15 +14,12 @@ const SlideDetails = styled.div`
     }
 
     .keen-slider {
-        width: 100%;
-        height: 40rem;
+        width: min(96vw, 1600px);
+        margin: 0 auto;
+        height: clamp(24rem, 60vw, 40rem);
 
         @media (max-width: 1366px) {
             height: 30rem;
-        }
-
-        @media (max-width: 500px) {
-            width: 28rem;
         }
 
         a {
@@ -31,7 +28,7 @@ const SlideDetails = styled.div`
 
         img {
             width: 100%;
-            height: 40rem;
+            height: clamp(24rem, 60vw, 40rem);
             object-fit: cover;
             filter: brightness(50%);
 
@@ -39,9 +36,6 @@ const SlideDetails = styled.div`
                 height: 30rem;
             }
 
-            @media (max-width: 500px) {
-                width: 28rem;
-            }
         }
 
         .keen-slider__slide {
@@ -55,17 +49,17 @@ const SlideDetails = styled.div`
                 text-transform: initial;
                 line-height: 40px;
                 text-align: left;
-                width: 58rem;
+                width: clamp(20rem, 70vw, 60rem);
 
                 @media (max-width: 1366px) {
                     width: 80%;
                 }
 
                 @media (max-width: 500px) {
-                    width: 85%;
-                    transform: scale(0.9);
-                    left: 0;
-                    top: 15%;
+                    width: 90%;
+                    transform: translate(-50%, -20%) scale(0.95);
+                    left: 50%;
+                    top: 20%;
                 }
 
                 @media (max-width: 375px) {

--- a/src/components/SlugDetails.tsx
+++ b/src/components/SlugDetails.tsx
@@ -29,42 +29,13 @@ const SlugDetails = styled.div`
     }
 
     section {
-        margin-left: 28rem;
-        width: 71%;
+        margin: 0 auto 5rem auto;
+        width: min(1100px, 100%);
+        padding: 0 1.5rem 1rem;
 
-        @media (max-width: 1920px) {
-            width: 50%;
-            margin: auto;
-            margin-bottom: 5%;
+        @media (min-width: 1921px) {
+            width: min(70%, 1400px);
         }
-
-        @media (max-width: 1600px) {
-            margin-left: 20rem;
-            width: 50%;
-        }
-
-        @media (max-width: 1440px) {
-            margin-left: 14rem;
-            width: 60%;
-        }
-
-        @media (max-width: 1366px) {
-            margin-left: 12rem;
-            width: 70%;
-        }
-
-        @media (max-width: 768px) {
-            margin-left: 5rem;
-            width: 80%;
-        }
-
-        @media (max-width: 500px) {
-            margin-left: 1rem;
-            width: 90%;
-        }
-
-        margin-bottom: 5rem;
-        padding-bottom: 1rem;
 
         h1 {
             margin-top: -1rem;
@@ -109,13 +80,12 @@ const SlugDetails = styled.div`
         }
 
         .date {
-            margin-bottom: 0rem;
-            margin-left: 48rem;
+            margin: 0;
+            text-align: right;
         }
 
         .block__content {
             width: 100%;
-            min-width: 80%;
             max-width: 100%;
             text-align: justify;
             font-size: 1.1rem;
@@ -142,22 +112,12 @@ const SlugDetails = styled.div`
         }
 
         .title__content {
-            width: 60rem;
-
-            @media (max-width: 1366px) {
-                width: 100%;
-            }
+            width: 100%;
+            max-width: 60rem;
 
             @media (max-width: 768px) {
                 font-size: 1.6em;
                 line-height: 30px;
-                width: 100%;
-            }
-
-            @media (max-width: 500px) {
-                font-size: 1.6em;
-                line-height: 30px;
-                width: 90%;
             }
         }
 
@@ -166,7 +126,8 @@ const SlugDetails = styled.div`
                 display: flex;
                 justify-content: center;
                 margin: 0 auto;
-                width: 80%;
+                width: 100%;
+                max-width: 80%;
                 height: 100%;
             }
         }
@@ -191,18 +152,13 @@ const SlugDetails = styled.div`
         }
 
         iframe {
-            width: 60rem;
+            width: 100%;
+            max-width: 60rem;
             margin-left: 0rem;
-            height: 38rem;
+            height: clamp(20rem, 50vw, 38rem);
             border: none;
 
-            @media (max-width: 500px) {
-                width: 100%;
-                height: 25rem;
-            }
-
             @media (max-width: 768px) {
-                width: 100%;
                 height: 25rem;
             }
         }


### PR DESCRIPTION
## Summary
- widen news and categories sections to fill larger displays while staying contained on small screens
- center the featured slider with fluid sizing to avoid overflow on mobile and scale up on 4K monitors
- simplify article page spacing so text, images, and embeds adapt cleanly across breakpoints

## Testing
- npm run lint *(fails: Next.js CLI reports `Invalid project directory provided` when running `next lint`)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923f3e13388833292ecf5c1b4b4d4ac)