### PR TITLE
Fix deterministic date formatting for hydration safety

### DIFF
--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,6 +1,41 @@
+const parseDate = (date: string) => {
+    if (!date) {
+        return null;
+    }
+
+    const fullMatch = date.match(/^(\d{4})-(\d{2})-(\d{2}):(\d{2}):(\d{2}):(\d{2})$/);
+    if (fullMatch) {
+        const [, year, month, day, hour, minute, second] = fullMatch;
+        return new Date(Date.UTC(
+            Number(year),
+            Number(month) - 1,
+            Number(day),
+            Number(hour),
+            Number(minute),
+            Number(second)
+        ));
+    }
+
+    const shortMatch = date.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (shortMatch) {
+        const [, year, month, day] = shortMatch;
+        return new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)));
+    }
+
+    const parsed = new Date(date);
+    if (Number.isNaN(parsed.getTime())) {
+        return null;
+    }
+
+    return parsed;
+};
+
 const formatDate = (date: string) => {
-    const d = new Date(date);
-    const year = d.getFullYear();
+    const d = parseDate(date);
+    if (!d) {
+        return '';
+    }
+    const year = d.getUTCFullYear();
 
     const monthNames = [
         "Janeiro",
@@ -17,9 +52,9 @@ const formatDate = (date: string) => {
         "Dezembro",
     ];
 
-    const day = String(d.getDate()).padStart(2, '0');
+    const day = String(d.getUTCDate()).padStart(2, '0');
 
-    return `${day} de ${monthNames[d.getMonth()]} de ${year}`;
+    return `${day} de ${monthNames[d.getUTCMonth()]} de ${year}`;
 }
 
 export default formatDate;


### PR DESCRIPTION
### Motivation
- Prevent hydration mismatches caused by dates rendering differently between server and client. 
- Avoid showing `NaN`/`undefined` when frontmatter `date` values use unexpected formats. 
- Normalize parsing so localized/timezone differences do not change the rendered date string. 

### Description
- Add a `parseDate` helper that parses `YYYY-MM-DD:HH:MM:SS`, `YYYY-MM-DD` and falls back to `new Date(...)` for other inputs. 
- Update `formatDate` to use `parseDate` and UTC getters (`getUTCFullYear`, `getUTCMonth`, `getUTCDate`) to produce deterministic output. 
- Return an empty string when parsing fails to avoid rendering `NaN`/`undefined` in the UI. 
- Change implemented in `src/utils/formatDate.ts`.

### Testing
- No automated tests were run for this change.
- Manual verification: code compiles and file `src/utils/formatDate.ts` was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69614f1f11708332b93091abdf64a552)