### PR TITLE
Add PWA support: manifest, service worker and theme color #0496dd

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,6 +11,12 @@ function MyApp({ Component, pageProps }) {
         fetch('/api/visit', {
             method: 'POST',
         });
+
+        if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.register('/sw.js');
+            });
+        }
     }, []);
 
     return (

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -66,7 +66,10 @@ export default class MyDocument extends Document {
 
                     <meta name="author" content="Anderson 'Yagasaki' Marlon" />
                     <meta name="robots" content="index, follow" />
+                    <meta name="theme-color" content="#0496dd" />
                     <link rel="shortcut icon" href="/logo.png" />
+                    <link rel="apple-touch-icon" href="/logo.png" />
+                    <link rel="manifest" href="/manifest.json" />
                     <meta property="og:locale" content="pt_BR" />
 
                     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "Onigiri Hardcore",
+  "short_name": "Onigiri",
+  "description": "Onigiri Hardcore | Portal de Notícias e Entretenimento",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0496dd",
+  "icons": [
+    {
+      "src": "/logo.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/logo.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,52 @@
+const CACHE_NAME = 'onigiri-hardcore-v1';
+const PRECACHE_URLS = ['/', '/manifest.json', '/logo.png'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) =>
+      Promise.all(
+        cacheNames
+          .filter((cacheName) => cacheName !== CACHE_NAME)
+          .map((cacheName) => caches.delete(cacheName))
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(event.request).then((response) => {
+        if (
+          !response ||
+          response.status !== 200 ||
+          response.type !== 'basic'
+        ) {
+          return response;
+        }
+
+        const responseToCache = response.clone();
+
+        caches.open(CACHE_NAME).then((cache) => {
+          cache.put(event.request, responseToCache);
+        });
+
+        return response;
+      });
+    })
+  );
+});


### PR DESCRIPTION
### Motivation
- Habilitar suporte PWA para permitir instalação e comportamento offline do site.
- Definir a cor do header/tema para `#0496dd` para bate com o design solicitado.
- Fornecer ícone Apple touch e um `manifest.json` para melhorar integração em dispositivos móveis.

### Description
- Adiciona meta `theme-color`, `apple-touch-icon` e link para `manifest.json` em `pages/_document.tsx` para configurar a aparência e instalação do PWA.
- Registra o service worker no carregamento da aplicação em `pages/_app.tsx` com `navigator.serviceWorker.register('/sw.js')`.
- Cria `public/manifest.json` contendo `theme_color: "#0496dd"`, `name`, `short_name`, `start_url`, e referências a `logo.png` para ícones.
- Cria `public/sw.js` implementando um service worker básico com precache (`'/'`, `'/manifest.json'`, `'/logo.png'`) e lógica de cache runtime sob o `CACHE_NAME` `'onigiri-hardcore-v1'`.

### Testing
- Nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962f0f741808332988abfb0eb8fb99b)