### PR TITLE
Force fresh news rendering and bypass SW cache

### DIFF
--- a/pages/noticias.tsx
+++ b/pages/noticias.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import Header from "../src/components/Header";
 import Footer from "../src/components/Footer";
 import LastNewsDetails from "../src/components/LastNewsDetails";
@@ -11,7 +11,8 @@ import matter from "gray-matter";
 import formatDate from "../src/utils/formatDate";
 import calculateReadingTime from "../src/utils/calculateReadingTime";
 
-export async function getStaticProps() {
+export async function getServerSideProps({ res }) {
+    res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate");
     // Get files from the posts dir
     const files = fs.readdirSync(path.join("posts"));
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'onigiri-hardcore-v1';
+const CACHE_NAME = 'onigiri-hardcore-v2';
 const PRECACHE_URLS = ['/', '/manifest.json', '/logo.png'];
 
 self.addEventListener('install', (event) => {
@@ -21,6 +21,12 @@ self.addEventListener('activate', (event) => {
 
 self.addEventListener('fetch', (event) => {
   if (event.request.method !== 'GET') {
+    return;
+  }
+
+  const requestUrl = new URL(event.request.url);
+  if (requestUrl.pathname.startsWith('/noticias')) {
+    event.respondWith(fetch(event.request));
     return;
   }
 


### PR DESCRIPTION
### Motivation
- The news listing was being served from stale caches causing users to see outdated posts and requiring hard refreshes.
- The goal is to guarantee always-up-to-date news by using server-side rendering and preventing service-worker/CDN caches from returning old content.

### Description
- Replaced `getStaticProps` with `getServerSideProps` in `pages/noticias.tsx` and set the response header `Cache-Control: no-store, no-cache, must-revalidate` to force fresh server-rendered content on every request.
- Updated the service worker `public/sw.js` to bump the cache version to `onigiri-hardcore-v2` (evicting old cache entries) and to bypass the SW cache for requests whose pathname starts with `/noticias` by responding with a direct `fetch` (network-first for that route).
- Removed an unused `useEffect` import from `pages/noticias.tsx` as part of the cleanup.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a493cf0b08332a9e1fa4bddff89e4)