### PR TITLE
perf: use next/image, add caching middleware, remote image config and font optimization

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const response = NextResponse.next();
+  const { pathname } = request.nextUrl;
+
+  if (pathname.startsWith('/_next/static') || pathname.startsWith('/images') || pathname.match(/\.(?:jpg|jpeg|png|webp|avif|svg|css|js)$/)) {
+    response.headers.set('Cache-Control', 'public, max-age=31536000, immutable');
+  } else {
+    response.headers.set('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=86400');
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: ['/((?!api|_next/image|favicon.ico).*)'],
+};

--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-
   compiler: {
     styledComponents: true,
+  },
+  images: {
+    remotePatterns: [{ protocol: 'https', hostname: '**' }],
   },
 };
 

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import Image from "next/image";
 
 import fs from "fs";
 import path from "path";
@@ -173,7 +174,7 @@ const Post = ({ frontmatter, slug, content }) => {
                     <title>{frontmatter.title + " | Onigiri Hardcore"}</title>
                 </Head>
 
-                {frontmatter.image && <img src={frontmatter.image} alt={frontmatter.title} width={1920} height={1080} />}
+                {frontmatter.image && <Image src={frontmatter.image} alt={frontmatter.title} width={1920} height={1080} priority sizes="100vw" />}
 
                 <section key={frontmatter.id}>
                     <p className="block__content">

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,16 +1,25 @@
 import { useEffect } from 'react';
+import { Roboto } from 'next/font/google';
 import '../styles/globals.css'
 import { Toaster } from 'sonner'
 import { Analytics } from '@vercel/analytics/react';
 import SnowOverlay from '../src/components/SnowOverlay';
 
+const roboto = Roboto({ subsets: ['latin'], weight: ['300', '400', '500', '700'], display: 'swap' });
+
 // eslint-disable-next-line react/prop-types
 function MyApp({ Component, pageProps }) {
 
     useEffect(() => {
-        fetch('/api/visit', {
+        const visitUrl = '/api/visit';
+
+        fetch(visitUrl, {
             method: 'POST',
-        });
+            cache: 'no-store',
+            headers: {
+                'Cache-Control': 'no-cache',
+            },
+        }).catch(() => {});
 
         if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
             window.addEventListener('load', () => {
@@ -20,12 +29,12 @@ function MyApp({ Component, pageProps }) {
     }, []);
 
     return (
-        <>
+        <div className={roboto.className}>
             <Component {...pageProps} />
             <Analytics />
             <Toaster richColors position="top-right" />
             <SnowOverlay/>
-        </>
+        </div>
     )
 }
 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -72,7 +72,6 @@ export default class MyDocument extends Document {
                     <link rel="manifest" href="/manifest.json" />
                     <meta property="og:locale" content="pt_BR" />
 
-                    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" />
                     <link rel="stylesheet" href="https://unicons.iconscout.com/release/v4.0.0/css/line.css" />
                 </Head>
                 <body>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/prop-types */
 import { NextSeo } from 'next-seo'
+import Image from 'next/image'
 import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter'
@@ -114,7 +115,7 @@ export default function Home({ postData }) {
                         {
                             firstAnime && firstAnime.map(post => (
                                 <a className='categories-content' href={post.slug} key={post.slug}>
-                                    <img src={post.frontmatter.image} alt={post.frontmatter.title} width={500} height={500} loading='lazy' />
+                                    <Image src={post.frontmatter.image} alt={post.frontmatter.title} width={500} height={500} sizes="(max-width: 768px) 100vw, 500px" />
                                     <h1>{post.frontmatter.title.length > 35 ? post.frontmatter.title.slice(0, 55) + "..." : post.frontmatter.title}</h1>
 
                                     <span>
@@ -131,7 +132,7 @@ export default function Home({ postData }) {
                                 lastAnime && lastAnime.map(post => (
                                     <div className="post" key={post.slug}>
                                         <a href={post.slug}>
-                                            <img src={post.frontmatter.image} alt={post.frontmatter.title} width={150} height={150} loading='lazy' />
+                                            <Image src={post.frontmatter.image} alt={post.frontmatter.title} width={150} height={150} sizes="150px" />
 
                                             <div className="post-side">
                                                 <h3>{post.frontmatter.title}</h3>
@@ -153,7 +154,7 @@ export default function Home({ postData }) {
                         {
                             firstGames && firstGames.map(post => (
                                 <a className='categories-content' href={post.slug} key={post.slug}>
-                                    <img src={post.frontmatter.image} alt={post.frontmatter.title} width={500} height={500} loading='lazy' />
+                                    <Image src={post.frontmatter.image} alt={post.frontmatter.title} width={500} height={500} sizes="(max-width: 768px) 100vw, 500px" />
                                     <h1>{post.frontmatter.title.length > 35 ? post.frontmatter.title.slice(0, 55) + "..." : post.frontmatter.title}</h1>
 
                                     <span>
@@ -169,7 +170,7 @@ export default function Home({ postData }) {
                                 lastGames && lastGames.map(post => (
                                     <div className="post" key={post.slug}>
                                         <a href={post.slug} >
-                                            <img src={post.frontmatter.image} alt={post.frontmatter.title} width={150} height={150} loading='lazy' />
+                                            <Image src={post.frontmatter.image} alt={post.frontmatter.title} width={150} height={150} sizes="150px" />
 
                                             <div className="post-side">
                                                 <h3>{post.frontmatter.title}</h3>
@@ -191,7 +192,7 @@ export default function Home({ postData }) {
                         {
                             firstMovies && firstMovies.map(post => (
                                 <a className='categories-content' href={post.slug} key={post.slug}>
-                                    <img src={post.frontmatter.image} alt={post.frontmatter.title} width={500} height={500} loading='lazy' />
+                                    <Image src={post.frontmatter.image} alt={post.frontmatter.title} width={500} height={500} sizes="(max-width: 768px) 100vw, 500px" />
                                     <h1>{post.frontmatter.title.length > 35 ? post.frontmatter.title.slice(0, 55) + "..." : post.frontmatter.title}</h1>
 
                                     <span>
@@ -208,7 +209,7 @@ export default function Home({ postData }) {
                                 lastMovies && lastMovies.map(post => (
                                     <div className="post" key={post.slug}>
                                         <a href={post.slug}>
-                                            <img src={post.frontmatter.image} alt={post.frontmatter.title} width={150} height={150} loading='lazy' />
+                                            <Image src={post.frontmatter.image} alt={post.frontmatter.title} width={150} height={150} sizes="150px" />
 
                                             <div className="post-side">
                                                 <h3>{post.frontmatter.title}</h3>
@@ -233,7 +234,7 @@ export default function Home({ postData }) {
                             {
                                 technologies.slice(0, 12).map((post) => (
                                     <a href={post.slug} key={post.slug}>
-                                        <img src={post.frontmatter.image} alt={post.frontmatter.title} width={150} height={150} loading='lazy' />
+                                        <Image src={post.frontmatter.image} alt={post.frontmatter.title} width={150} height={150} sizes="150px" />
 
                                         <div className="title">
                                             <h1>{post.frontmatter.title}</h1>
@@ -256,7 +257,7 @@ export default function Home({ postData }) {
                                 <div className="content" key={post.slug}>
                                     <div className="leftContent">
                                         <a href={post.slug}>
-                                            <img src={post.frontmatter.image} alt={post.frontmatter.title} width={150} height={150} loading='lazy' />
+                                            <Image src={post.frontmatter.image} alt={post.frontmatter.title} width={150} height={150} sizes="150px" />
                                         </a>
                                     </div>
                                     <div className="rightContent">

--- a/pages/noticias.tsx
+++ b/pages/noticias.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import Image from "next/image";
 import Header from "../src/components/Header";
 import Footer from "../src/components/Footer";
 import LastNewsDetails from "../src/components/LastNewsDetails";
@@ -104,7 +105,7 @@ const Noticias = ({ postData }) => {
                                 <div className="content" key={index}>
                                     <div className="leftContent">
                                         <a href={post.slug}>
-                                            <img src={post.frontmatter.image} alt={post.frontmatter.title} width={150} height={150} loading="lazy" />
+                                            <Image src={post.frontmatter.image} alt={post.frontmatter.title} width={150} height={150} sizes="150px" />
                                         </a>
                                     </div>
                                     <div className="rightContent">

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const response = NextResponse.next();
   const { pathname } = request.nextUrl;
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -8,7 +8,7 @@ export function middleware(request: NextRequest) {
   if (pathname.startsWith('/_next/static') || pathname.startsWith('/images') || pathname.match(/\.(?:jpg|jpeg|png|webp|avif|svg|css|js)$/)) {
     response.headers.set('Cache-Control', 'public, max-age=31536000, immutable');
   } else {
-    response.headers.set('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=86400');
+    response.headers.set('Cache-Control', 'public, max-age=0, must-revalidate');
   }
 
   return response;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 import { useRouter } from "next/router";
 import { HeaderDetails, HeaderMobile } from "./HeaderDetails";
 
@@ -65,7 +66,7 @@ const Header = () => {
                 <HeaderMobile ref={drawnerRef}>
                     {/*<MenuOutlined className={open ? `menu active` : `menu`} onClick={() => setOpen(!open)} />*/}
                     <div className="logo-drawner">
-                        {uwu ? <img src="/uwu.png" className="logotipo" alt="logo" /> : <img src="/logotipo.png" className="logotipo" alt="logo" />}
+                        {uwu ? <Image src="/uwu.png" className="logotipo" alt="logo" width={180} height={52} priority sizes="(max-width: 600px) 140px, 180px" /> : <Image src="/logotipo.png" className="logotipo" alt="logo" width={180} height={52} priority sizes="(max-width: 600px) 140px, 180px" />}
                     </div>
                     <AnimatePresence>
                         {open && (
@@ -96,7 +97,7 @@ const Header = () => {
                 <HeaderDetails>
                     <div className="header">
                         <Link href="/">
-                            {uwu ? <img src="/uwu.png" className="uwu" alt="logo" /> : <img src="/logotipo.png" className="logotipo" alt="logo" />}
+                            {uwu ? <Image src="/uwu.png" className="uwu" alt="logo" width={180} height={52} priority sizes="(max-width: 900px) 140px, 180px" /> : <Image src="/logotipo.png" className="logotipo" alt="logo" width={180} height={52} priority sizes="(max-width: 900px) 140px, 180px" />}
                         </Link>
                     </div>
 

--- a/src/components/Slide.tsx
+++ b/src/components/Slide.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import Image from "next/image";
 
 import "keen-slider/keen-slider.min.css";
 import SlideDetails from "./SlideDetails";
@@ -67,7 +68,7 @@ const Slide = ({ posts }) => {
                         postsData.slice(0, 5).map((post) => (
                             <div className="keen-slider__slide" key={post}>
                                 <a href={post.slug}>
-                                    <img src={post.frontmatter.image} alt={post.frontmatter.title} width={1920} height={1080} loading="lazy" />
+                                    <Image src={post.frontmatter.image} alt={post.frontmatter.title} width={1920} height={1080} priority={postsData.indexOf(post) === 0} sizes="100vw" />
                                 </a>
                                 <div className="slider-description">
                                     <div className="slide-tag">


### PR DESCRIPTION
### Motivation
- Improve page load and Lighthouse metrics by converting raster `<img>` usage to Next.js optimized `next/image`, marking above-the-fold assets as `priority`, and adding responsive `sizes` attributes. 
- Reduce unnecessary network traffic and enable stale-while-revalidate by introducing site-wide cache headers via middleware. 
- Replace external Google Fonts stylesheet with `next/font/google` to avoid render-blocking font requests and use `display: 'swap'` for better CLS and FOUT behavior. 

### Description
- Migrated key images from `<img>` to `next/image` and added `sizes` and `priority` to above-the-fold assets in `pages/index.tsx`, `pages/noticias.tsx`, `pages/[slug].tsx`, `src/components/Header.tsx`, and `src/components/Slide.tsx`. 
- Created `middleware.ts` to set `Cache-Control` headers (long immutable cache for static assets and `s-maxage` + `stale-while-revalidate` for pages) and configured its matcher to exclude `api` and image optimization routes. 
- Replaced external Google Fonts usage by adding `Roboto` via `next/font/google` in `pages/_app.tsx` and removed the external `<link>` in `pages/_document.tsx`. 
- Added `images.remotePatterns` to `next.config.js` to allow `next/image` to load remote CMS-hosted images. 
- Hardened the client-side telemetry `fetch('/api/visit')` call in `pages/_app.tsx` to use `cache: 'no-store'` and explicit `Cache-Control` headers to avoid accidental caching. 

### Testing
- Ran repository checks and diffs with `git status --short` and `git diff` which completed successfully. 
- Committed changes with `git commit` which succeeded and produced a new commit containing the edits. 
- Performed local source inspections of modified files (`pages/_app.tsx`, `pages/_document.tsx`, `pages/index.tsx`, `pages/noticias.tsx`, `pages/[slug].tsx`, `src/components/Header.tsx`, `src/components/Slide.tsx`, `next.config.js`, `middleware.ts`) and validated the intended code edits were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0899638098832094e564458e732d1a)